### PR TITLE
Add RS256 support

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 
 ** Implemented so far
    - Issue unsecured tokens
-   - Issue tokens secured with HS256
+   - Issue tokens secured with HS256 and RS256
    - Decode and verify tokens
 
 ** To do

--- a/src/cljwt.lisp
+++ b/src/cljwt.lisp
@@ -28,7 +28,8 @@
   (:import-from #:ironclad
                 #:make-hmac
                 #:update-hmac
-                #:hmac-digest)
+                #:hmac-digest
+                #:encrypt-message)
   (:import-from #:split-sequence
                 #:split-sequence)
   (:export #:issue
@@ -37,12 +38,21 @@
            #:from-unix-time
            #:unsecured-token
            #:invalid-hmac
+           #:invalid-rs256-signature
            #:unsupported-algorithm
            #:invalid-time
            #:expired
            #:not-yet-valid))
 
 (in-package #:cljwt)
+
+(defconstant +sha256-prefix+ #(#x30 #x31 #x30 #x0d #x06 #x09 #x60 #x86 #x48 #x01 #x65 #x03 #x04 #x02 #x01 #x05 #x00 #x04 #x20))
+
+(defconstant +rs256-padding+ (concatenate '(vector (unsigned-byte 8))
+                                          #(#x00 #x01)
+                                          (make-array '(74) :element-type '(unsigned-byte 8) :initial-element #xff)
+                                          #(#x00)
+                                          +sha256-prefix+))
 
 (defmacro bind-hash-tables (bindings &body body)
   `(let ,(loop for binding in bindings collect
@@ -74,10 +84,10 @@
      (with-output-to-string (out)
        (with-input-from-string (in (usb8-array-to-base64-string input :uri t))
          (loop for character = (read-char in nil)
-               while character do
-                 ;; CL-BASE64 always uses padding, which must be removed.
-                 (unless (eq character #\.)
-                   (write-char character out))))))))
+            while character do
+            ;; CL-BASE64 always uses padding, which must be removed.
+              (unless (eq character #\.)
+                (write-char character out))))))))
 
 (defun base64-decode (base-64-string)
   "Takes a base64-uri string and return an array of octets"
@@ -90,7 +100,7 @@
                             :initial-element #\.))
    :uri t))
 
-(defun issue (claims &key algorithm secret issuer subject audience
+(defun issue (claims &key algorithm key issuer subject audience
                        expiration not-before issued-at id more-header)
   "Encodes and returns a JSON Web Token. Times are in universal-time,
 number of seconds from 1900-01-01 00:00:00"
@@ -110,7 +120,8 @@ number of seconds from 1900-01-01 00:00:00"
                 "typ" "JWT"
                 "alg" (ecase algorithm
                         (:none "none")
-                        (:hs256 "HS256")))
+                        (:hs256 "HS256")
+                        (:rs256 "RS256")))
     ;; Prepare JSON
     (let ((header-string (base64-encode
                           (with-output-to-string (s)
@@ -122,10 +133,14 @@ number of seconds from 1900-01-01 00:00:00"
       (format nil "~A.~A.~@[~A~]"
               header-string
               claims-string
-              (when (eq algorithm :hs256)
-                (HS256-digest header-string
-                              claims-string
-                              secret))))))
+              (ecase algorithm
+                (:none nil)
+                (:hs256 (HS256-digest header-string
+                                      claims-string
+                                      key))
+                (:rs256 (RS256-digest header-string
+                                      claims-string
+                                      key)))))))
 
 (defun HS256-digest (header-string claims-string secret)
   "Takes header and claims in Base64, secret as a string or octets,
@@ -147,6 +162,28 @@ returns the digest, in Base64"
                   (string-to-octets
                    claims-string))))))
 
+(defun RS256-clear-padded-digest (header-string claims-string)
+  "Takes header and claims in Base64 returns the non-crypted, padded digest, as octets"
+  (concatenate '(vector (unsigned-byte 8))
+               +rs256-padding+
+               (ironclad:digest-sequence
+                :sha256
+                (concatenate '(vector (unsigned-byte 8))
+                             (string-to-octets
+                              header-string)
+                             #(46)      ; ASCII period (.)
+                             (string-to-octets
+                              claims-string)))))
+
+
+(defun RS256-digest (header-string claims-string private-key)
+  "Takes header and claims in Base64, private-key as an ironclad rsa private-key,
+returns the digest, in Base64"
+  (base64-encode (encrypt-message
+                  private-key
+                  (RS256-clear-padded-digest header-string claims-string))))
+
+
 (defun compare-HS256-digest (header-string claims-string
                              secret reported-digest)
   "Takes header and claims in Base64, secret as a string or octets, and a digest in Base64 to compare with. Signals an error if there is a mismatch."
@@ -155,12 +192,32 @@ returns the digest, in Base64"
                        claims-string
                        secret)))
     (unless (equalp computed-digest
-                   reported-digest)
+                    reported-digest)
       (cerror "Continue anyway" 'invalid-hmac
-             :reported-digest reported-digest
-             :computed-digest computed-digest))))
+              :reported-digest reported-digest
+              :computed-digest computed-digest))))
 
-(defun decode (jwt-string &key secret fail-if-unsecured)
+(defun compare-RS256-digest (header-string claims-string
+                             public-key reported-digest)
+  "Takes header and claims in Base64, public-key as an ironclad rsa private-key, and a
+digest in Base64 to compare with. Signals an error if there is a mismatch."
+  (let ((computed-clear-digest
+         (RS256-clear-padded-digest header-string
+                                    claims-string))
+        (reported-clear-digest
+         (encrypt-message
+          public-key
+          (base64-decode reported-digest))))
+    ;; compare from 1 in the computer-clear-digest, as the encryption procedure
+    ;; discards the first null byte
+    (if (mismatch computed-clear-digest
+                  reported-clear-digest :start1 1)
+        (cerror "Continue anyway" 'invalid-rs256-signature
+                :reported-digest reported-clear-digest
+                :computed-digest computed-clear-digest))))
+
+
+(defun decode (jwt-string &key key fail-if-unsecured)
   "Decodes and verifies a JSON Web Token. Returns two hash tables,
 token claims and token header"
   (destructuring-bind (header-string claims-string digest-string)
@@ -180,7 +237,12 @@ token claims and token header"
       (cond ((equal algorithm "HS256")
              (compare-HS256-digest header-string
                                    claims-string
-                                   secret
+                                   key
+                                   digest-string))
+            ((equal algorithm "RS256")
+             (compare-RS256-digest header-string
+                                   claims-string
+                                   key
                                    digest-string))
             ((and (or (null algorithm) (equal algorithm "none")) fail-if-unsecured)
              (cerror "Continue anyway" 'unsecured-token))
@@ -202,6 +264,8 @@ token claims and token header"
 (define-condition unsecured-token (error) ())
 
 (define-condition invalid-hmac (error) ())
+
+(define-condition invalid-rs256-signature (error) ())
 
 (define-condition unsupported-algorithm (error)
   ((algorithm :initarg :algorithm :reader algorithm))


### PR DESCRIPTION
Adding support for the RS256 algorithm. No changes in the issue/decode functions signatures other than renaming the "secret" parameter to "key". It must contain the secret, if HS256, as before, or public/private key if RS256 (for decoding/issuing, respectively).

To test, using the rs256 example in http://jwt.io :

```common-lisp

;; Creating the keys
(setf publickey-modulus (parse-integer "00dd95ab518d18e8828dd6a238061c51d82ee81d516018f624777f2e1aad6340d4aa12f24570df770989b5ebf1bbf05005296ab0b096f75b1fa76f10e7e8bb4fe008542c1d47d0ad20eff8cb9250c01ef23cca138a96fa32bec5053d6b4dc652728792495ef90d295ff83a8d767baf5ff100ae43a36910f97e712bd722a518042b" :radix 16))

(setf privatekey-exponent (parse-integer "0fea2702d5727b889ced547b579d0317d6ce9f0470357ac045c0e1abd2d6351ad118494449861343a11b6ad5d2dcc0b28e35f678c86efda1796215c1c24a69c3183e10e9977a1f8cccbed9876f383ae3db920940686855f5b6faff90a9b866f57acc8f6d85be4f2d8f0b419265f217917b3bea35c0bbd4ce06f0f4c9b7366259" :radix 16))

(setf public-key (ironclad:make-public-key :rsa
                                           :n publickey-modulus :e 65537))

(setf private-key (ironclad:make-private-key :rsa :n publickey-modulus :d privatekey-exponent))


;;; Decode the example JWT string, using the public key
(cljwt:decode "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE"
 :key public-key)

;;; test the issue and then decode
(cljwt:decode (cljwt:issue (alexandria:plist-hash-table
                            '("sub" "1234567890" "name" "John Doe" "admin" t)
                            :test #'equal)
                           :algorithm :rs256
                           :key private-key)
              :key public-key)
```